### PR TITLE
Re-enable ability to override the database driver that's used

### DIFF
--- a/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 
@@ -76,13 +77,17 @@ public class DatabaseAutoConfiguration {
     }
 
     protected DataSource buildDataSource() throws ClassNotFoundException {
+        String driverClassName = props.getDriver();
         DatabaseDriver driver = DatabaseDriver.fromJdbcUrl(props.getUrl());
+        if (StringUtils.isEmpty(driverClassName)) {
+            driverClassName = driver.getDriverClassName();
+        }
         org.apache.tomcat.jdbc.pool.DataSource ds = DataSourceBuilder
                 .create()
                 .username(props.getUser())
                 .password(props.getPassword())
                 .url(props.getUrl())
-                .driverClassName(driver.getDriverClassName())
+                .driverClassName(driverClassName)
                 .type(org.apache.tomcat.jdbc.pool.DataSource.class)
                 .build();
 


### PR DESCRIPTION
This change allows the implementation to easily explicitly set the driver class they would like to use instead of always using the class that Spring recommends based on the database url.

We previously updated this method that builds the datasource to always use Spring's default driver class based on the url of the database. In general this is a good solution as it removes the requirement for implementations to know which driver they need to use. However, with Spring Boot 2.1.x it is now recommended to use `com.mysql.cj.jdbc.Driver` when targeting a MySQL database but `com.mysql.jdbc.Driver` performs better, especially with commits. With this change logging has been added to still encourage implementations to not specify a driver class when they're not using MySQL but also makes the implementers aware that they need to specify the driver class `com.mysql.jdbc.Driver` when using MySQL and Spring Boot 2.1.x+. This change still allows implementations to delegate to Spring to detect the driver even with Spring Boot 2.1.x+ and MySQL however they will be notified that it is not recommended.