### PR TITLE
Add connection pool properties to DBProperties

### DIFF
--- a/src/main/java/com/broadleafcommerce/autoconfigure/DBProperties.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/DBProperties.java
@@ -35,6 +35,16 @@ public class DBProperties {
 
     protected String url;
 
+    protected Integer initialSize;
+
+    protected Integer maxActive;
+
+    protected Integer maxIdle;
+
+    protected Integer maxWait;
+
+    protected Integer minIdle;
+
     public String getType() {
         return type;
     }
@@ -71,5 +81,45 @@ public class DBProperties {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public Integer getInitialSize() {
+        return initialSize;
+    }
+
+    public void setInitialSize(Integer initialSize) {
+        this.initialSize = initialSize;
+    }
+
+    public Integer getMaxActive() {
+        return maxActive;
+    }
+
+    public void setMaxActive(Integer maxActive) {
+        this.maxActive = maxActive;
+    }
+
+    public Integer getMaxIdle() {
+        return maxIdle;
+    }
+
+    public void setMaxIdle(Integer maxIdle) {
+        this.maxIdle = maxIdle;
+    }
+
+    public Integer getMaxWait() {
+        return maxWait;
+    }
+
+    public void setMaxWait(Integer maxWait) {
+        this.maxWait = maxWait;
+    }
+
+    public Integer getMinIdle() {
+        return minIdle;
+    }
+
+    public void setMinIdle(Integer minIdle) {
+        this.minIdle = minIdle;
     }
 }

--- a/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
@@ -102,6 +102,26 @@ public class DatabaseAutoConfiguration {
             ds.setValidationQuery(validationQuery);
         }
 
+        if (props.getInitialSize() != null) {
+            ds.setInitialSize(props.getInitialSize());
+        }
+
+        if (props.getMaxActive() != null) {
+            ds.setMaxActive(props.getMaxActive());
+        }
+
+        if (props.getMaxIdle() != null) {
+            ds.setMaxIdle(props.getMaxIdle());
+        }
+
+        if (props.getMaxWait() != null) {
+            ds.setMaxWait(props.getMaxWait());
+        }
+
+        if (props.getMaxIdle() != null) {
+            ds.setMinIdle(props.getMaxIdle());
+        }
+
         return ds;
     }
 


### PR DESCRIPTION
Since the OOB Spring Boot properties can't be used to configure these settings and the only option would be to manually override the datasource configuration it's useful to add a way to configure the connection pool.

https://github.com/BroadleafCommerce/QA/issues/4092