### PR TITLE
DatabaseAutoConfiguration is incorrectly setting maxIdle twice

### DIFF
--- a/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
@@ -45,7 +45,7 @@ public class DatabaseAutoConfiguration {
     private final String NEW_MYSQL = "com.mysql.cj.jdbc.Driver";
 
     @Autowired
-    DBProperties props;
+    protected DBProperties props;
 
     @ConditionalOnMissingBean(name={"webDS"})
     @Bean
@@ -116,10 +116,6 @@ public class DatabaseAutoConfiguration {
 
         if (props.getMaxWait() != null) {
             ds.setMaxWait(props.getMaxWait());
-        }
-
-        if (props.getMaxIdle() != null) {
-            ds.setMinIdle(props.getMaxIdle());
         }
 
         return ds;

--- a/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
+++ b/src/main/java/com/broadleafcommerce/autoconfigure/DatabaseAutoConfiguration.java
@@ -114,6 +114,10 @@ public class DatabaseAutoConfiguration {
             ds.setMaxIdle(props.getMaxIdle());
         }
 
+        if (props.getMinIdle() != null) {
+            ds.setMinIdle(props.getMinIdle());
+        }
+
         if (props.getMaxWait() != null) {
             ds.setMaxWait(props.getMaxWait());
         }


### PR DESCRIPTION
Description:
The DatabaseAutoConfiguration iin the broadleaf-boot-starter-database project s setting maxIdle twice. Also, the "props" field should be changed to protected.

https://github.com/BroadleafCommerce/QA/issues/4166